### PR TITLE
[FEATURE]보고서관리 - 보고서조회 - 매출보고서 승인/반려

### DIFF
--- a/src/pages/admin/report/reportsMenu/BranchSalesDetail.js
+++ b/src/pages/admin/report/reportsMenu/BranchSalesDetail.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
 import { calldetailBranchSalesAPI } from '../../../../apis/ReportAPICalls';
+import axios from 'axios';
 import './BranchSalesDetail.css';
 import jwtDecode from 'jwt-decode';
 
@@ -9,22 +10,42 @@ function BranchSalesDetail() {
   const params = useParams();
   const dispatch = useDispatch();
   const branchSalesDetail = useSelector(state => state.detailBranchSalesReducer);
-  const members  = jwtDecode(window.localStorage.getItem('accessToken'))
+  const members = jwtDecode(window.localStorage.getItem('accessToken'));
   const navigate = useNavigate();
 
-  console.log('memers page',members)
+  console.log('members page', members);
 
   useEffect(() => {
     dispatch(calldetailBranchSalesAPI({
-        branchReportCode: params.branchReportCode
+      branchReportCode: params.branchReportCode
     }));
   }, [dispatch, params.branchReportCode]);
 
   const handleClose = () => {
     navigate('/company/paper/reports', { state: { activeTable: '매출' } });
-  }
+  };
 
+  const handleApproval = async () => {
+    try {
+      await axios.put(`/paper/company/reports/approve/${params.branchReportCode}`);
+      alert('승인되었습니다.');
+      navigate('/company/paper/reports', { state: { activeTable: '매출' } });
+    } catch (error) {
+      console.error('승인에 실패하였습니다.', error);
+      alert('승인에 실패하였습니다.');
+    }
+  };
 
+  const handleRejection = async () => {
+    try {
+      await axios.put(`/paper/company/reports/reject/${params.branchReportCode}`);
+      alert('반려되었습니다.');
+      navigate('/company/paper/reports', { state: { activeTable: '매출' } });
+    } catch (error) {
+      console.error('반려에 실패하였습니다.', error);
+      alert('반려에 실패하였습니다.');
+    }
+  };
 
   return (
     <div className="branchDetail_menu1_layout">
@@ -80,11 +101,12 @@ function BranchSalesDetail() {
           </table>
           <div className="formButtons">
             {
-              members.memberRole === 'a' && 
-              (<>
-                <button>승인</button>
-                <button>반려</button>
-              </>)
+              members.memberRole === 'a' && (
+                <>
+                  <button onClick={handleApproval}>승인</button>
+                  <button onClick={handleRejection}>반려</button>
+                </>
+              )
             }
             <button onClick={handleClose}>닫기</button>
           </div>

--- a/src/pages/admin/report/reportsMenu/ExpenseDetail.js
+++ b/src/pages/admin/report/reportsMenu/ExpenseDetail.js
@@ -1,67 +1,99 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
-import { callDetailExpenseAPI } from '../../../../apis/ReportAPICalls';
+import { calldetailBranchSalesAPI } from '../../../../apis/ReportAPICalls';
+import axios from 'axios';
 import './BranchSalesDetail.css';
 import jwtDecode from 'jwt-decode';
 
-function ExpenseDetail() {
+function BranchSalesDetail() {
   const params = useParams();
   const dispatch = useDispatch();
-  const expenseDetail = useSelector(state => state.detailExpenseReducer);
-  const members  = jwtDecode(window.localStorage.getItem('accessToken'))
+  const branchSalesDetail = useSelector(state => state.detailBranchSalesReducer);
+  const members = jwtDecode(window.localStorage.getItem('accessToken'));
   const navigate = useNavigate();
 
-
   useEffect(() => {
-    dispatch(callDetailExpenseAPI({
-      expenseReportCode: params.expenseReportCode
+    dispatch(calldetailBranchSalesAPI({
+      branchReportCode: params.branchReportCode
     }));
-  }, [dispatch, params.expenseReportCode]);
+  }, [dispatch, params.branchReportCode]);
 
   const handleClose = () => {
-    navigate('/company/paper/reports', { state: { activeTable: '지출' } });
+    navigate('/company/paper/reports', { state: { activeTable: '매출' } });
   }
 
+  const handleApproval = async () => {
+    try {
+      await axios.put(`/paper/company/reports/approve/${params.branchReportCode}`);
+      alert('승인되었습니다.');
+      navigate('/company/paper/reports', { state: { activeTable: '매출' } });
+    } catch (error) {
+      console.error('승인에 실패하였습니다.', error);
+      alert('승인에 실패하였습니다.');
+    }
+  }
 
-  console.log('여까지 왔어?')
+  const handleRejection = async () => {
+    try {
+      await axios.put(`/paper/company/reports/reject/${params.branchReportCode}`);
+      alert('반려되었습니다.');
+      navigate('/company/paper/reports', { state: { activeTable: '매출' } });
+    } catch (error) {
+      console.error('반려에 실패하였습니다.', error);
+      alert('반려에 실패하였습니다.');
+    }
+  }
+
   return (
     <div className="branchDetail_menu1_layout">
       <div className="branchDetail_flex_wrap">
         <div className="details-container">
-          <h1 className="title">지출보고서 상세보기</h1>
+          <h1 className="title">매출보고서 상세보기</h1>
           <table className="details-table">
             <thead>
               <tr>
                 <th>양식명</th>
-                <td colSpan="2">{expenseDetail.expenseReportCode}</td>
+                <td colSpan="2">{branchSalesDetail.branchReportCode}</td>
                 <th>지점장명</th>
                 <td colSpan="2"></td>
               </tr>
               <tr>
                 <th>지점명</th>
-                <td>{expenseDetail.branchCode}</td>
+                <td>{branchSalesDetail.branchCode}</td>
                 <th>제출일</th>
-                <td colSpan="3">{new Date(expenseDetail.expenseSubmissionDate).toLocaleDateString()}</td>
+                <td colSpan="3">{new Date(branchSalesDetail.branchSubmissionDate).toLocaleDateString()}</td>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <th rowSpan="8" className="vertical-header">내용</th>
-                <th className="header">전기세</th>
-                <td colSpan="4">{expenseDetail.electricityBill}</td>
+                <th className="header">세제</th>
+                <td colSpan="4">{branchSalesDetail.detergent}</td>
               </tr>
               <tr>
-                <th className="header">수도세</th>
-                <td colSpan="4">{expenseDetail.waterBill}</td>
+                <th className="header">섬유유연제</th>
+                <td colSpan="4">{branchSalesDetail.fabricSoftener}</td>
               </tr>
               <tr>
-                <th className="header">가스비</th>
-                <td colSpan="4">{expenseDetail.gasBill}</td>
+                <th className="header">표백제</th>
+                <td colSpan="4">{branchSalesDetail.bleach}</td>
               </tr>
               <tr>
-                <th className="header">알바비</th>
-                <td colSpan="4">{expenseDetail.partTimeSalary}</td>
+                <th className="header">얼룩제거제</th>
+                <td colSpan="4">{branchSalesDetail.stainRemover}</td>
+              </tr>
+              <tr>
+                <th className="header">세탁조 클리너</th>
+                <td colSpan="4">{branchSalesDetail.washerCleaner}</td>
+              </tr>
+              <tr>
+                <th className="header">건조기시트</th>
+                <td colSpan="4">{branchSalesDetail.dryerSheet}</td>
+              </tr>
+              <tr>
+                <th className="header">오프라인매출</th>
+                <td colSpan="4">{branchSalesDetail.officeSales}</td>
               </tr>
             </tbody>
           </table>
@@ -69,8 +101,8 @@ function ExpenseDetail() {
             {
               members.memberRole === 'a' && 
               (<>
-                <button>승인</button>
-                <button>반려</button>
+                <button onClick={handleApproval}>승인</button>
+                <button onClick={handleRejection}>반려</button>
               </>)
             }
             <button onClick={handleClose}>닫기</button>
@@ -78,11 +110,7 @@ function ExpenseDetail() {
         </div>
       </div>
     </div>
-
-    
   );
 }
 
-console.log('여기는 왔니...?')
-export default ExpenseDetail;
-
+export default BranchSalesDetail;

--- a/src/pages/client/locationReports/locationNewReportsMenu/LocationNewReports.css
+++ b/src/pages/client/locationReports/locationNewReportsMenu/LocationNewReports.css
@@ -15,24 +15,24 @@
   }
   
   /* 보고서 작성 페이지 css */
-  /* .report-create {
+  .report-create {
     width: 100%;
     margin: 20px 0; 
   }
-   */
-  /* .report-create h1 {
+
+  .report-create h1 {
     font-size: 45px;
     margin-bottom: 20px;
     border-bottom: 1px solid #000;
     padding-bottom: 10px;
-  } */
+  }
   
-  /* .button-group {
+  .button-group {
     display: flex;
     justify-content: end; 
     margin-bottom: 20px;
-  } */
-/*   
+  }
+
   .register-button,
   .create-button {
     padding: 10px 20px;
@@ -107,4 +107,3 @@
     background-color: #000;
     color: #fff;
   }
-   */


### PR DESCRIPTION

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 관리자(member_id -> 'a'시작하는 ) 는 매출보고서 상세조회시 승인/반려 버튼이 추가된다.
- 관리자(member_id -> 'a'시작하는 ) 는 매출보고서 상세조회시 승인/반려 버튼을 눌러 상태변화를 시킬 수 있다.


  <br/>

## 이미지 첨부

<img src="https://github.com/user-attachments/assets/98f9b850-b5c3-4f5a-b290-a5c43c9e7bc7" width="50%" height="50%"/>

<img src="https://github.com/user-attachments/assets/78bb4959-32fd-47bd-9593-307c7817579c" width="50%" height="50%"/>

<img src="https://github.com/user-attachments/assets/d99fd2fa-93f2-40a8-9484-a9042cdf671c" width="50%" height="50%"/>

<br/>


## ➕ 이슈 링크

- [레포 이름 #62 ]

<br/>
